### PR TITLE
chore: rename virtualenvs_inproject to virtualenvs_in_project

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Once installed you are responsible for adding the poetry paths to your PATH envi
 ## Role Variables
 Available variables are listed below, along with default values (see defaults/main.yml):
 
-    virtualenvs_inproject: false
+    virtualenvs_in_project: false
     virtualenvs_prefer_active_python: false
     poetry_ohmyzsh_plugin: false
 
@@ -35,7 +35,7 @@ or with variables:
       roles:
         - role: bartdorlandt.poetry
           vars:
-            virtualenvs_inproject: true
+            virtualenvs_in_project: true
             virtualenvs_prefer_active_python: true
             poetry_ohmyzsh_plugin: true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-virtualenvs_inproject: false
+virtualenvs_in_project: false
 virtualenvs_prefer_active_python: false
 poetry_ohmyzsh_plugin: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,11 +19,11 @@
       ansible.builtin.command: poetry config virtualenvs.in-project
       register: poetry_in_project
       changed_when: false
-      when: virtualenvs_inproject
+      when: virtualenvs_in_project
 
     - name: Configure Poetry virtualenvs.in-project
       ansible.builtin.command: poetry config virtualenvs.in-project true
-      when: virtualenvs_inproject and poetry_in_project.stdout != "true"
+      when: virtualenvs_in_project and poetry_in_project.stdout != "true"
 
     - name: Check Poetry virtualenvs.prefer-active-python config
       ansible.builtin.command: poetry config virtualenvs.prefer-active-python


### PR DESCRIPTION
Official one is `virtualenvs.in-project` based on https://python-poetry.org/docs/configuration/#virtualenvsin-project

So just rename `virtualenvs_inproject` to `virtualenvs_in_project`  to be more consistent.

It is a small breaking change, but I think it is worth it especially right now it is early stage. Hope it makes sense. Thanks! 😃